### PR TITLE
Implement execution model in worker

### DIFF
--- a/common/src/job_manage.rs
+++ b/common/src/job_manage.rs
@@ -135,8 +135,8 @@ pub struct JobCancelResult {
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct JobPingResult {
     pub job: Job,
-    pub response_timestamp: Timestamp, //Time to get response
-    pub responses: Vec<PingResponse>,
+    //pub response_timestamp: Timestamp, //Time to get response
+    pub response: PingResponse,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
@@ -214,7 +214,7 @@ impl JobResult {
         match job.job_detail.as_ref().unwrap() {
             JobDetail::Ping(_) => JobResult::Ping(JobPingResult {
                 job: job.clone(),
-                response_timestamp: current_timestamp,
+                //response_timestamp: current_timestamp,
                 ..Default::default()
             }),
             JobDetail::Compound(_) => JobResult::Compound(JobCompoundResult {

--- a/common/src/tasks/ping/generator.rs
+++ b/common/src/tasks/ping/generator.rs
@@ -51,6 +51,7 @@ impl TaskApplicant for PingGenerator {
         log::debug!("TaskPing apply for component {:?}", component);
         let job_ping = JobPing {};
         let mut job = Job::new(JobDetail::Ping(job_ping));
+        job.parallelable = true;
         job.component_url = self.get_url(component);
         job.time_out = self.config.ping_timeout_ms;
         job.repeat_number = self.config.ping_sample_number;

--- a/fisherman/src/lib.rs
+++ b/fisherman/src/lib.rs
@@ -32,6 +32,8 @@ lazy_static! {
     pub static ref BENCHMARK_WRK_PATH: String =
         env::var("BENCHMARK_WRK_PATH").unwrap_or("./".to_string());
     pub static ref MAX_THREAD_COUNTER: usize = env::var("MAX_THREAD_COUNTER").map_or(4, |val|{ val.parse::<usize>().unwrap_or(4)});
+    //Waiting time period for parallelable threads in milliseconds
+    pub static ref WAITING_TIME_FOR_EXECUTING_THREAD: u64 = env::var("WAITING_TIME_FOR_EXECUTING_THREAD").map_or(100, |val|{ val.parse::<u64>().unwrap_or(100)});
         //.unwrap_or(Strin"4").parse::<usize>().unwrap();
     pub static ref LOCAL_IP: String = local_ip_address::local_ip().unwrap().to_string();
     pub static ref HASH_TEST_20K: String = "95c5679435a0a714918dc92b546dc0ba".to_string();

--- a/fisherman/src/models/job.rs
+++ b/fisherman/src/models/job.rs
@@ -13,9 +13,37 @@ impl JobBuffer {
         self.jobs.push(job);
     }
     pub fn add_jobs(&mut self, mut jobs: Vec<Job>) {
-        self.jobs.append(&mut jobs);
+        for job in jobs {
+            //Find index for new job
+            let mut next_ind = self.jobs.len();
+            for (ind, item) in self.jobs.iter().enumerate() {
+                if job.expected_runtime > 0 {
+                    if job.expected_runtime < item.expected_runtime {
+                        next_ind = ind;
+                        break;
+                    }
+                } else if item.expected_runtime == 0 && job.priority < item.priority {
+                    next_ind = ind;
+                    break;
+                }
+            }
+            self.jobs.insert(next_ind, job);
+        }
     }
     pub fn pop_job(&mut self) -> Option<Job> {
-        self.jobs.pop()
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("Unix time doesn't go backwards; qed")
+            .as_millis();
+        let first_expected_time = self
+            .jobs
+            .first()
+            .and_then(|job| Some(job.expected_runtime))
+            .unwrap_or(0_128);
+        if first_expected_time < current_time {
+            self.jobs.pop()
+        } else {
+            None
+        }
     }
 }

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -23,7 +23,7 @@ lazy_static! {
     pub static ref SCHEDULER_ENDPOINT: String =
         env::var("SCHEDULER_ENDPOINT").unwrap_or(String::from("0.0.0.0:3031"));
     pub static ref REPORT_CALLBACK: String =
-        env::var("REPORT_CALLBACK").unwrap_or(String::from("http://192.168.1.30:3031/report"));
+        env::var("REPORT_CALLBACK").unwrap_or(String::from("http://127.0.0.1:3031/report"));
     pub static ref SCHEDULER_CONFIG: String =
         env::var("SCHEDULER_CONFIG").unwrap_or(String::from("config_fisherman.json"));
     pub static ref CONNECTION_POOL_SIZE: u32 = env::var("CONNECTION_POOL_SIZE")
@@ -32,9 +32,7 @@ lazy_static! {
         .unwrap_or(20);
     pub static ref PORTAL_AUTHORIZATION: String =
         env::var("PORTAL_AUTHORIZATION").expect("There is no env var PORTAL_AUTHORIZATION");
-    pub static ref DATABASE_URL: String = env::var("DATABASE_URL").unwrap_or(String::from(
-        "postgres://fisherman:FishermanCodelight123@35.193.163.173:5432/massbit-fisherman"
-    ));
+    pub static ref DATABASE_URL: String = env::var("DATABASE_URL").unwrap();
     pub static ref REPORT_DIR: String =
         env::var("REPORT_DIR").expect("There is no env var REPORT_DIR");
     pub static ref SIGNER_PHRASE: String =

--- a/scheduler/src/report_processors/eth/benchamark.rs
+++ b/scheduler/src/report_processors/eth/benchamark.rs
@@ -14,7 +14,10 @@ impl BenchmarkReportProcessor {
 }
 impl ReportProcessor for BenchmarkReportProcessor {
     fn can_apply(&self, report: &JobResult) -> bool {
-        true
+        match report {
+            JobResult::Benchmark(_) => true,
+            _ => false,
+        }
     }
 
     fn process_job(&self, report: &JobResult, db_connection: Arc<DatabaseConnection>) {

--- a/scheduler/src/report_processors/eth/random_block.rs
+++ b/scheduler/src/report_processors/eth/random_block.rs
@@ -14,7 +14,10 @@ impl RandomBlockReportProcessor {
 }
 impl ReportProcessor for RandomBlockReportProcessor {
     fn can_apply(&self, report: &JobResult) -> bool {
-        true
+        match report {
+            JobResult::Benchmark(_) => true,
+            _ => false,
+        }
     }
 
     fn process_job(&self, report: &JobResult, db_connection: Arc<DatabaseConnection>) {

--- a/scheduler/src/report_processors/ping_report.rs
+++ b/scheduler/src/report_processors/ping_report.rs
@@ -18,7 +18,10 @@ impl PingReportProcessor {
 }
 impl ReportProcessor for PingReportProcessor {
     fn can_apply(&self, report: &JobResult) -> bool {
-        true
+        match report {
+            JobResult::Ping(_) => true,
+            _ => false,
+        }
     }
 
     fn process_job(&self, report: &JobResult, db_connection: Arc<DatabaseConnection>) {
@@ -29,9 +32,7 @@ impl ReportProcessor for PingReportProcessor {
         for report in reports {
             match report {
                 JobResult::Ping(ping_result) => {
-                    for response in ping_result.responses {
-                        println!("{:?}", &response);
-                    }
+                    println!("{:?}", &ping_result.response);
                     //println!("{:?}", &ping_result);
                 }
                 _ => {}


### PR DESCRIPTION
For repeated job, after each execution, create new job and put it back to the job queue